### PR TITLE
Add new full.h header (see #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ ROSFMT_INFO("Here is my string: {str}. And a number: {num}",
 );
 ```
 
+Using `rosfmt/full.h` you can print types with `std::ostream` operators
+(ROS messages, Eigen types) and ranges such as `std::vector`:
+
+```C++
+#include <rosfmt/full.h>
+
+auto x = Eigen::Matrix3d::Identity();
+ROSFMT_INFO("My matrix x:\n{}", x);
+```
+
 Of course, you can also use fmt's API directly:
 
 ```C++

--- a/include/rosfmt/full.h
+++ b/include/rosfmt/full.h
@@ -1,0 +1,11 @@
+// rosfmt - type-safe ROS_* logging macros: Full version
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
+#ifndef ROSFMT_FULL_H
+#define ROSFMT_FULL_H
+
+#include <rosfmt/rosfmt.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,12 +1,11 @@
 // Simple compilation test
 // Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
 
-#include <rosfmt/rosfmt.h>
+#include <rosfmt/full.h>
 
 int main(int argc, char** argv)
 {
 	ROSFMT_INFO("Hello world");
 	ROSFMT_INFO("This is five: {}", 5);
-
 	return 0;
 }


### PR DESCRIPTION
Offers `std::ostream` and ranges support at the cost of increased compile times. See #2 for details.