### PR TITLE
Use latest C++ instead of 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,6 @@ include_directories(
 	${catkin_INCLUDE_DIRS}
 )
 
-set(CMAKE_CXX_STANDARD 11)
-
 set_source_files_properties(
 	${fmt_SOURCE_DIR}/src/format.cc
 	${fmt_SOURCE_DIR}/src/os.cc


### PR DESCRIPTION
This avoids 'error: ‘shared_mutex’ in namespace ‘std’ does not name a type' error related to log4cxx versions in Ubuntu 22.04 and later.

Building in melodic and noetic should be fine, 18.04 has C++11 by default and 20.04 is 17 (though I'm not seeing a good reference page that shows this at the moment).
