### PR TITLE
allow compile time checking of string (missing placeholders, etc)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ add_custom_target(fmt_headers
 catkin_package(
 	INCLUDE_DIRS include ${fmt_HEADER_DEST}
 	CATKIN_DEPENDS roscpp rosconsole
-	LIBRARIES rosfmt7
+	LIBRARIES rosfmt9
 )
 
 include_directories(
@@ -65,21 +65,21 @@ set_source_files_properties(
 	PROPERTIES GENERATED TRUE
 )
 
-add_library(rosfmt7
+add_library(rosfmt9
 	${fmt_HEADERS_OUT}
 	${fmt_SOURCE_DIR}/src/format.cc
 	${fmt_SOURCE_DIR}/src/os.cc
 	src/rosfmt.cpp
 )
-target_link_libraries(rosfmt7
+target_link_libraries(rosfmt9
 	${catkin_LIBRARIES}
 )
-add_dependencies(rosfmt7 fmt fmt_headers)
+add_dependencies(rosfmt9 fmt fmt_headers)
 
 add_executable(simple_test
 	test/test.cpp
 )
-target_link_libraries(simple_test rosfmt7)
+target_link_libraries(simple_test rosfmt9)
 add_test(
 	NAME SimpleTest
 	COMMAND simple_test
@@ -99,6 +99,6 @@ install(
 	DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 install(
-	TARGETS rosfmt7
+	TARGETS rosfmt9
 	DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
 include(ExternalProject)
 ExternalProject_Add(
 	fmt
-	URL https://github.com/fmtlib/fmt/releases/download/7.1.2/fmt-7.1.2.zip
-	URL_HASH SHA256=4d6968ab7c01e95cc76df136755703defb985105a117b83057e4fd5d53680ea7
+	URL https://github.com/fmtlib/fmt/releases/download/9.1.0/fmt-9.1.0.zip
+	URL_HASH SHA256=cceb4cb9366e18a5742128cb3524ce5f50e88b476f1e54737a47ffdf4df4c996
 	CONFIGURE_COMMAND ""
 
 	# We touch all downloaded files, otherwise they get some timestamp in the
@@ -28,7 +28,7 @@ set(fmt_SOURCE_DIR "${SOURCE_DIR}")
 set(fmt_HEADER_DEST "${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}")
 
 file(MAKE_DIRECTORY ${fmt_HEADER_DEST})
-foreach(FILE chrono.h color.h compile.h core.h format-inl.h format.h locale.h os.h ostream.h posix.h printf.h ranges.h)
+foreach(FILE args.h chrono.h color.h compile.h core.h format-inl.h format.h os.h ostream.h printf.h ranges.h std.h xchar.h)
 	set(in "${fmt_SOURCE_DIR}/include/fmt/${FILE}")
 	set(out "${fmt_HEADER_DEST}/fmt/${FILE}")
 	list(APPEND fmt_HEADERS_OUT ${out})

--- a/include/rosfmt/rosfmt.h
+++ b/include/rosfmt/rosfmt.h
@@ -28,6 +28,13 @@ namespace rosfmt
 
 std::string vformat(fmt::string_view format_str, fmt::format_args args);
 
+template<typename ... Args>
+std::string format(const std::string& formatString, const Args& ... args)
+{
+	fmt::format_arg_store<fmt::format_context, Args...> as{args...};
+	return rosfmt::vformat(formatString, as);
+}
+
 template<typename... Args>
 void print(
 	ros::console::FilterBase* filter, void* logger, ros::console::Level level,

--- a/include/rosfmt/rosfmt.h
+++ b/include/rosfmt/rosfmt.h
@@ -10,6 +10,13 @@
 
 #else
 
+// Enable old auto-detection of std::ostream operators
+#ifndef ROSFMT_NO_DEPRECATED_OSTREAM
+#ifndef FMT_DEPRECATED_OSTREAM
+#define FMT_DEPRECATED_OSTREAM
+#endif
+#endif
+
 #include <ros/console.h>
 
 #include <fmt/core.h>

--- a/include/rosfmt/rosfmt.h
+++ b/include/rosfmt/rosfmt.h
@@ -28,20 +28,13 @@ namespace rosfmt
 
 std::string vformat(fmt::string_view format_str, fmt::format_args args);
 
-template<typename ... Args>
-std::string format(const std::string& formatString, const Args& ... args)
-{
-	fmt::format_arg_store<fmt::format_context, Args...> as{args...};
-	return rosfmt::vformat(formatString, as);
-}
-
 template<typename... Args>
 void print(
 	ros::console::FilterBase* filter, void* logger, ros::console::Level level,
 	const char* file, int line, const char* function,
-	const std::string& format, const Args&... args)
+	fmt::format_string<Args...> fmt, Args&&... args)
 {
-	std::string s = rosfmt::format(format, args...);
+	std::string s = rosfmt::vformat(fmt, fmt::make_format_args(std::forward<Args>(args)...));
 	std::stringstream ss;
 	ss << s;
 	ros::console::print(filter, logger, level, ss, file, line, function);


### PR DESCRIPTION
This change allows for compile time checking of the format string, such as an extra placeholder without an argument. tested on fmt 9.1.0